### PR TITLE
Add support for storing role and meta data as json

### DIFF
--- a/example/example.cabal
+++ b/example/example.cabal
@@ -35,7 +35,7 @@ Executable example
     resource-pool-catchio >= 0.2 && < 0.3,
     xmlhtml >= 0.1,
     either  == 3.1.*,
-    errors  >= 1.3 && < 1.4
+    errors  >= 1.3 && < 1.5
 
   if flag(development)
     build-depends:

--- a/snaplet-sqlite-simple.cabal
+++ b/snaplet-sqlite-simple.cabal
@@ -47,6 +47,7 @@ Library
     Paths_snaplet_sqlite_simple
 
   build-depends:
+    aeson                      >= 0.6     && < 0.7,
     base                       >= 4       && < 5,
     bytestring                 >= 0.9.1   && < 0.11,
     clientsession              >= 0.8     && < 0.9,
@@ -77,6 +78,7 @@ test-suite test
                   , SafeCWD
 
   build-depends:
+    aeson                      >= 0.6      && < 0.7,
     HUnit                      >= 1.2      && < 2,
     MonadCatchIO-transformers  >= 0.2      && < 0.4,
     base                       >= 4        && < 5,
@@ -85,7 +87,7 @@ test-suite test
     configurator               >= 0.1      && < 0.3,
     containers                 >= 0.3,
     directory                  >= 1.0      && < 1.3,
-    errors                     >= 1.3.1    && < 1.4,
+    errors                     >= 1.3.1    && < 1.5,
     lens                       >= 3.7.0.1  && < 3.9,
     mtl                        >= 2,
     snap-core,
@@ -97,7 +99,8 @@ test-suite test
     test-framework-hunit       >= 0.2.7    && < 0.4,
     text                       >= 0.11     && < 0.12,
     time                       >= 1.1,
-    transformers               >= 0.2
+    transformers               >= 0.2,
+    unordered-containers       >= 0.2     && < 0.3
 
   default-extensions:
     FlexibleInstances

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -6,6 +6,9 @@ module Tests
 
 
 ------------------------------------------------------------------------------
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Char8 as BL
+import qualified Data.HashMap.Lazy as HM
 import qualified Data.Map as M
 import qualified Data.Text as T
 import           Test.Framework
@@ -129,6 +132,8 @@ testCreateUserGood = testCase "createUser good params" assertGoodUser
       assertEqual "local host ip" Nothing (userLastLoginIp u)
       assertEqual "locked until" Nothing (userLockedOutUntil u)
       assertEqual "empty email" Nothing (userEmail u)
+      assertEqual "roles" [] (userRoles u)
+      assertEqual "meta" HM.empty (userMeta u)
 
 ------------------------------------------------------------------------------
 -- Create a user, modify it, persist it and load again, check fields ok.
@@ -150,16 +155,26 @@ testUpdateUser = testCase "createUser + update good params" assertGoodUser
       assertEqual "locked until" Nothing (userLockedOutUntil u)
       assertEqual "local host ip" (Just "127.0.0.1") (userCurrentLoginIp u)
       assertEqual "no previous login" Nothing (userLastLoginIp u)
-      let saveHdl = with auth $ saveUser (u { userLogin = "bar" })
+      let saveHdl = with auth $ saveUser (u { userLogin = "bar"
+                                            , userRoles = roles
+                                            , userMeta  = meta })
       res <- evalHandler (ST.get "" M.empty) saveHdl appInit
       either (assertFailure . show) checkUpdatedUser res
 
+    roles = [Role $ BL.pack "Superman", Role $ BL.pack "Journalist"]
+    meta  = HM.fromList [ (T.pack "email-verified",
+                           A.toJSON $ T.pack "yes")
+                        , (T.pack "suppress-products",
+                           A.toJSON [T.pack "Kryptonite"]) ]
+          
     checkUpdatedUser (Left _) = assertBool "failed saveUser" False
     checkUpdatedUser (Right u) = do
       assertEqual "login rename ok?"  "bar" (userLogin u)
       assertEqual "login count"  1 (userLoginCount u)
       assertEqual "local host ip" (Just "127.0.0.1") (userCurrentLoginIp u)
       assertEqual "local host ip" Nothing (userLastLoginIp u)
+      assertEqual "account roles"  roles (userRoles u)
+      assertEqual "account meta data" meta (userMeta u)
       let loginHdl = with auth $ loginByUsername "bar" (ClearText "foo") True
       res <- evalHandler (ST.get "" M.empty) loginHdl appInit
       either (assertFailure . show) (assertBool "login as 'bar' ok?" . isRight) res


### PR DESCRIPTION
This is the branch with your 'Text' changes.
I've added tests, but they actually fail with this version.  I have verified that the tests pass with the ByteString version.

Encode empty roles/meta data as NULLs in the database

Favor using Data.Text over ByteStrings for storing JSON text in the
database.

This patch requires the latest sqlite-simple version from github.
This will be released shortly on hackage.
