### PR TITLE
Allow snap-0.14

### DIFF
--- a/snaplet-sqlite-simple.cabal
+++ b/snaplet-sqlite-simple.cabal
@@ -52,11 +52,12 @@ Library
     bytestring                 >= 0.9.1   && < 0.11,
     clientsession              >= 0.8     && < 0.10,
     configurator               >= 0.2     && < 0.4,
+    lens                       >= 3.7.6   && < 5,
     MonadCatchIO-transformers  >= 0.3     && < 0.4,
     mtl                        >= 2       && < 3,
     sqlite-simple              >= 0.4.1   && < 1.0,
     direct-sqlite              >= 2.3.3   && < 2.4,
-    snap                       >= 0.13    && < 0.14,
+    snap                       >= 0.13    && < 0.15,
     text                       >= 0.11    && < 1.3,
     transformers               >= 0.3     && < 0.5,
     unordered-containers       >= 0.2     && < 0.3

--- a/src/Snap/Snaplet/Auth/Backends/SqliteSimple.hs
+++ b/src/Snap/Snaplet/Auth/Backends/SqliteSimple.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
 {-|
@@ -39,6 +40,9 @@ module Snap.Snaplet.Auth.Backends.SqliteSimple
 
 ------------------------------------------------------------------------------
 import           Control.Concurrent
+import           Control.Lens ((^#))
+import           Control.Monad
+import           Control.Monad.IO.Class
 import qualified Data.Aeson as A
 import           Data.ByteString (ByteString)
 import qualified Data.Configurator as C

--- a/src/Snap/Snaplet/SqliteSimple.hs
+++ b/src/Snap/Snaplet/SqliteSimple.hs
@@ -87,6 +87,7 @@ module Snap.Snaplet.SqliteSimple (
 import           Prelude hiding (catch)
 
 import           Control.Concurrent
+import           Control.Lens ((^#))
 import           Control.Monad.CatchIO hiding (Handler)
 import           Control.Monad.IO.Class
 import           Control.Monad.State


### PR DESCRIPTION
* The lens dependency is needed because `Snap` stopped exporting `Control.Lens.Loupe`.
* `{-# LANGUAGE FlexibleContexts #-}` is needed because of GHC 7.10.